### PR TITLE
Fixed typo preventing motor powers below 100%

### DIFF
--- a/seesaw_motor.h
+++ b/seesaw_motor.h
@@ -48,7 +48,7 @@ public:
 
 		value = constrain(value, -1.0, 1.0);
 		_throttle = value;
-		uint16_t absolute = abs(value) * 65535;
+		uint16_t absolute = fabs(value) * 65535;
 
 		if(value > 0){
 			_ss->analogWrite(_pina, 0);


### PR DESCRIPTION
fabs inputs and outputs doubles (as opposed to abs which uses integers, and fabsf which uses floats). abs(value) takes all values below 100% power and rounds them down to 0% power.