### PR TITLE
NeoPixels: Clear buffer on seesaw as well (fixes #20)

### DIFF
--- a/seesaw_neopixel.cpp
+++ b/seesaw_neopixel.cpp
@@ -284,7 +284,17 @@ uint16_t seesaw_NeoPixel::numPixels(void) const {
 }
 
 void seesaw_NeoPixel::clear() {
+  // Clear local pixel buffer
   memset(pixels, 0, numBytes);
+
+  // Now clear the pixels on the seesaw
+  uint8_t writeBuf[32];
+  memset(writeBuf, 0, 32);
+  for(uint8_t offset = 0; offset < numBytes; offset += 32-4) {
+    writeBuf[0] = (offset >> 8);
+    writeBuf[1] = offset;
+    this->write(SEESAW_NEOPIXEL_BASE, SEESAW_NEOPIXEL_BUF, writeBuf, 32);
+  }
 }
 
 void seesaw_NeoPixel::setBrightness(uint8_t b) {


### PR DESCRIPTION
The NeoPixel `clear()` method currently only clears the local buffer, not the buffer on the seesaw.
Unfortunately there is no clear command in the firmware, so we can use the `SEESAW_NEOPIXEL_BUF` a few times to set the buffer to 0s.

Reproduce case:

```c
#include "Adafruit_NeoTrellis.h"

Adafruit_NeoTrellis pad;

void setup() {
  pad.begin();
}

void loop() {
  for (int i = 0; i < pad.pixels.numPixels(); ++i) {
    pad.pixels.setPixelColor(i, 255, 0, 0);
  }
  pad.pixels.show();
  delay(1000);
  pad.pixels.clear();
  pad.pixels.show();
  delay(1000);
}
```

We must call it multiple times because we can only send 32 bytes maximum.