### PR TITLE
Improve touchRead delay/retry handling

### DIFF
--- a/Adafruit_seesaw.cpp
+++ b/Adafruit_seesaw.cpp
@@ -273,8 +273,8 @@ uint16_t Adafruit_seesaw::touchRead(uint8_t pin) {
   uint8_t buf[2];
   uint8_t p = pin;
   uint16_t ret = 65535;
-  bool worked = this->read(SEESAW_TOUCH_BASE, SEESAW_TOUCH_CHANNEL_OFFSET + p, buf, 2,
-              1000, 3);
+  bool worked = this->read(SEESAW_TOUCH_BASE, SEESAW_TOUCH_CHANNEL_OFFSET + p,
+                           buf, 2, 1000, 3);
   if (worked) {
     ret = ((uint16_t)buf[0] << 8) | buf[1];
   }
@@ -645,8 +645,8 @@ uint8_t Adafruit_seesaw::getKeypadCount() {
  *  @param		count the number of events to read
  ****************************************************************************************/
 void Adafruit_seesaw::readKeypad(keyEventRaw *buf, uint8_t count) {
-  this->read(SEESAW_KEYPAD_BASE, SEESAW_KEYPAD_FIFO, (uint8_t *)buf,
-                    count, 1000);
+  this->read(SEESAW_KEYPAD_BASE, SEESAW_KEYPAD_FIFO, (uint8_t *)buf, count,
+             1000);
 }
 
 /**

--- a/Adafruit_seesaw.cpp
+++ b/Adafruit_seesaw.cpp
@@ -646,7 +646,7 @@ uint8_t Adafruit_seesaw::getKeypadCount() {
  *  @param		count the number of events to read
  ****************************************************************************************/
 void Adafruit_seesaw::readKeypad(keyEventRaw *buf, uint8_t count) {
-  return this->read(SEESAW_KEYPAD_BASE, SEESAW_KEYPAD_FIFO, (uint8_t *)buf,
+  this->read(SEESAW_KEYPAD_BASE, SEESAW_KEYPAD_FIFO, (uint8_t *)buf,
                     count, 1000);
 }
 
@@ -776,8 +776,9 @@ void Adafruit_seesaw::_i2c_init() {
  *	@param		delay an optional delay in between setting the read
  *register and reading out the data. This is required for some seesaw functions
  *(ex. reading ADC data)
+ *	@return		false if the operation failed
  ****************************************************************************************/
-void Adafruit_seesaw::read(uint8_t regHigh, uint8_t regLow, uint8_t *buf,
+bool Adafruit_seesaw::read(uint8_t regHigh, uint8_t regLow, uint8_t *buf,
                            uint8_t num, uint16_t delay) {
   uint8_t pos = 0;
 
@@ -819,6 +820,7 @@ void Adafruit_seesaw::read(uint8_t regHigh, uint8_t regLow, uint8_t *buf,
     Serial.println();
 #endif
   }
+  return true;
 }
 
 /*!

--- a/Adafruit_seesaw.h
+++ b/Adafruit_seesaw.h
@@ -288,7 +288,7 @@ protected:
   void write8(byte regHigh, byte regLow, byte value);
   uint8_t read8(byte regHigh, byte regLow, uint16_t delay = 125);
 
-  void read(uint8_t regHigh, uint8_t regLow, uint8_t *buf, uint8_t num,
+  bool read(uint8_t regHigh, uint8_t regLow, uint8_t *buf, uint8_t num,
             uint16_t delay = 125);
   void write(uint8_t regHigh, uint8_t regLow, uint8_t *buf, uint8_t num);
   void writeEmpty(uint8_t regHigh, uint8_t regLow);

--- a/Adafruit_seesaw.h
+++ b/Adafruit_seesaw.h
@@ -289,7 +289,7 @@ protected:
   uint8_t read8(byte regHigh, byte regLow, uint16_t delay = 125);
 
   bool read(uint8_t regHigh, uint8_t regLow, uint8_t *buf, uint8_t num,
-            uint16_t delay = 125);
+            uint16_t delay = 125, int retries = 1);
   void write(uint8_t regHigh, uint8_t regLow, uint8_t *buf, uint8_t num);
   void writeEmpty(uint8_t regHigh, uint8_t regLow);
   void _i2c_init();


### PR DESCRIPTION
Alternative to #25 

- fixes infinite loop stall in `touchRead` when sensor is not connected
- avoids delays and read attempts if the i2c transaction fails (checking return value of `endTransaction()`)
- fixes `touchRead(0)` not working with latest soil sensor firmware which requires a longer delay
- improves logging when `SEESAW_I2C_DEBUG` is enabled to cover retries and failure modes

cc @ladyada @mihai-dinculescu 