### PR TITLE
Remove extra depends from library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=This is a library for the Adafruit seesaw helper IC.
 category=Other
 url=https://github.com/adafruit/Adafruit_Seesaw
 architectures=*
-depends=Adafruit ST7735 and ST7789 Library
+depends=


### PR DESCRIPTION
-Removed "Adafruit ST7735 and ST7789 Library" from depends line in library.properties. It is not necessary for this library and breaks support for any board not supported by the SD library downstream, including ESP8266 boards.

-No known limitations.

-Tested this change against the current 1.3.1 release and it compiled without error along with functioning as expected on an ESP8266 board.