### PR TITLE
Fix warnings identified by -Wall -Wextra

### DIFF
--- a/Adafruit_NeoKey_1x4.cpp
+++ b/Adafruit_NeoKey_1x4.cpp
@@ -88,14 +88,14 @@ uint8_t Adafruit_NeoKey_1x4::read(void) {
     for (int b = 0; b < 4; b++) {
       if (just_pressed & (1 << b)) { // if button b is pressed
         if (_callbacks[b] != NULL) {
-          keyEvent evt = {SEESAW_KEYPAD_EDGE_RISING, b};
+          keyEvent evt = {SEESAW_KEYPAD_EDGE_RISING, (uint16_t)b};
           _callbacks[b](evt);
         }
       }
 
       if (just_released & (1 << b)) { // if button b is released
         if (_callbacks[b] != NULL) {
-          keyEvent evt = {SEESAW_KEYPAD_EDGE_FALLING, b};
+          keyEvent evt = {SEESAW_KEYPAD_EDGE_FALLING, (uint16_t)b};
           _callbacks[b](evt);
         }
       }
@@ -317,13 +317,13 @@ void Adafruit_MultiNeoKey1x4::read() {
 
           if (just_pressed & (1 << b)) { // if button b is pressed
             if (nk->_callbacks[b] != NULL) {
-              keyEvent evt = {SEESAW_KEYPAD_EDGE_RISING, event_key};
+              keyEvent evt = {SEESAW_KEYPAD_EDGE_RISING, (uint16_t)event_key};
               nk->_callbacks[b](evt);
             }
           }
           if (just_released & (1 << b)) { // if button b is pressed
             if (nk->_callbacks[b] != NULL) {
-              keyEvent evt = {SEESAW_KEYPAD_EDGE_FALLING, event_key};
+              keyEvent evt = {SEESAW_KEYPAD_EDGE_FALLING, (uint16_t)event_key};
               nk->_callbacks[b](evt);
             }
           }

--- a/Adafruit_NeoKey_1x4.h
+++ b/Adafruit_NeoKey_1x4.h
@@ -20,7 +20,6 @@
 
 #define NEOKEY_1X4_MAX_CALLBACKS 32
 
-#define NEOKEY_1X4_KEY(x) (((x) / 4) * 8 + ((x) % 4))
 #define NEOKEY_1X4_KEY(x) (((x) / 8) * 4 + ((x) % 8))
 
 #define NEOKEY_1X4_X(k) ((k) % 4)

--- a/Adafruit_NeoKey_1x4.h
+++ b/Adafruit_NeoKey_1x4.h
@@ -20,6 +20,8 @@
 
 #define NEOKEY_1X4_MAX_CALLBACKS 32
 
+/* NEOKEY_1X4_KEY depends on PCB routing */
+// #define NEOKEY_1X4_KEY(x) (((x) / 4) * 8 + ((x) % 4))
 #define NEOKEY_1X4_KEY(x) (((x) / 8) * 4 + ((x) % 8))
 
 #define NEOKEY_1X4_X(k) ((k) % 4)


### PR DESCRIPTION
Minor narrowing conversions, and an immediately overridden `#define`.

The conversions are very straightforward, but the two `#define NEOKEY_1X4_KEY`
right after each other I don't understand.  This PR removes the first one
(which is overridden anyway right now) and has the same behavior as master,
but I have no hardware with which to actually test if, instead, the first
definition should have been used (and second remoced instead).

Found while adding Adafruit_TinyUSB_Arduino to CI on the community
Raspberry Pi Pico Arduino core CI.

