### PR TITLE
seesaw_neopixel::clear(): Fix write buffer size

### DIFF
--- a/seesaw_neopixel.cpp
+++ b/seesaw_neopixel.cpp
@@ -284,13 +284,15 @@ void seesaw_NeoPixel::clear() {
   // Clear local pixel buffer
   memset(pixels, 0, numBytes);
 
-  // Now clear the pixels on the seesaw
-  uint8_t writeBuf[32];
-  memset(writeBuf, 0, 32);
+  // Now clear the pixels on the seesaw.
+  // Max write buffer size is I2C buffer limit (32 bytes) minus sizes
+  // for seesaw regHigh (1 byte) and regLow (1 byte).
+  uint8_t writeBuf[30];
+  memset(writeBuf, 0, 30);
   for (uint8_t offset = 0; offset < numBytes; offset += 32 - 4) {
     writeBuf[0] = (offset >> 8);
     writeBuf[1] = offset;
-    this->write(SEESAW_NEOPIXEL_BASE, SEESAW_NEOPIXEL_BUF, writeBuf, 32);
+    this->write(SEESAW_NEOPIXEL_BASE, SEESAW_NEOPIXEL_BUF, writeBuf, 30);
   }
 }
 


### PR DESCRIPTION
Fix buffer size exceeding I2C limit of 32 bytes in writes to seesaw. Currently, the code ignores additional two register bytes being prepended, causing `seesaw_neopixel::clear()` to silently fail.
