### PR TITLE
Update multiple_encoders.ino

### DIFF
--- a/examples/encoder/multiple_encoders/multiple_encoders.ino
+++ b/examples/encoder/multiple_encoders/multiple_encoders.ino
@@ -98,11 +98,18 @@ void loop() {
 #if USE_OLED
   display.clearDisplay();
 #endif
-
+  
   uint16_t display_line = 1;
   
   for (uint8_t enc=0; enc<sizeof(found_encoders); enc++) { 
+     bool pushed = false;
      if (found_encoders[enc] == false) continue;
+     if (! encoders[enc].digitalRead(SS_SWITCH)) {
+        Serial.print("Encoder #");
+        Serial.print(enc);
+        Serial.println(" pressed");
+        pushed = true;
+     }
   
      int32_t new_position = encoders[enc].getEncoderPosition();
      // did we move around?
@@ -125,16 +132,10 @@ void loop() {
      display.print(enc);
      display.print(" : ");
      display.print(encoder_positions[enc]);
-#endif
-
-     if (! encoders[enc].digitalRead(SS_SWITCH)) {
-        Serial.print("Encoder #");
-        Serial.print(enc);
-        Serial.println(" pressed");
-#if USE_OLED
-        display.print(" P");
-#endif
+     if(pushed){
+         display.print(" P");
      }
+#endif
   }
   
 #if USE_OLED


### PR DESCRIPTION
The current example for the multiple encoders reads a button pressed every time the encoder moves.  Simply putting the check for the button press before the encoder position check solved that problem.  The button pressed is only detected now when it is actually pressed rather than whenever the encoder is rotated.  I'm not sure why this is so but it must have something to do with the seesaw picking it that pin as being pulled to ground for some reason.  I can't really explain why it makes a difference, I only know that it didn't work before but now it does. 

Also, on the single encoder example, the button read is before the position read and it also does not have this problem.   But if you switch it to after it does exhibit the same problem.  

I tested using a Trinket M0 and Feather Huzzah ESP8266.