### PR TITLE
Add Audio_Spectrum example

### DIFF
--- a/Adafruit_seesaw.h
+++ b/Adafruit_seesaw.h
@@ -53,9 +53,10 @@ enum {
   SEESAW_TOUCH_BASE = 0x0F,
   SEESAW_KEYPAD_BASE = 0x10,
   SEESAW_ENCODER_BASE = 0x11,
+  SEESAW_SPECTRUM_BASE = 0x12,
 };
 
-/** GPIO module function addres registers
+/** GPIO module function address registers
  */
 enum {
   SEESAW_GPIO_DIRSET_BULK = 0x02,
@@ -71,7 +72,7 @@ enum {
   SEESAW_GPIO_PULLENCLR = 0x0C,
 };
 
-/** status module function addres registers
+/** status module function address registers
  */
 enum {
   SEESAW_STATUS_HW_ID = 0x01,
@@ -81,7 +82,7 @@ enum {
   SEESAW_STATUS_SWRST = 0x7F,
 };
 
-/** timer module function addres registers
+/** timer module function address registers
  */
 enum {
   SEESAW_TIMER_STATUS = 0x00,
@@ -89,7 +90,7 @@ enum {
   SEESAW_TIMER_FREQ = 0x02,
 };
 
-/** ADC module function addres registers
+/** ADC module function address registers
  */
 enum {
   SEESAW_ADC_STATUS = 0x00,
@@ -100,7 +101,7 @@ enum {
   SEESAW_ADC_CHANNEL_OFFSET = 0x07,
 };
 
-/** Sercom module function addres registers
+/** Sercom module function address registers
  */
 enum {
   SEESAW_SERCOM_STATUS = 0x00,
@@ -110,7 +111,7 @@ enum {
   SEESAW_SERCOM_DATA = 0x05,
 };
 
-/** neopixel module function addres registers
+/** neopixel module function address registers
  */
 enum {
   SEESAW_NEOPIXEL_STATUS = 0x00,
@@ -121,13 +122,13 @@ enum {
   SEESAW_NEOPIXEL_SHOW = 0x05,
 };
 
-/** touch module function addres registers
+/** touch module function address registers
  */
 enum {
   SEESAW_TOUCH_CHANNEL_OFFSET = 0x10,
 };
 
-/** keypad module function addres registers
+/** keypad module function address registers
  */
 enum {
   SEESAW_KEYPAD_STATUS = 0x00,
@@ -155,6 +156,20 @@ enum {
   SEESAW_ENCODER_INTENCLR = 0x20,
   SEESAW_ENCODER_POSITION = 0x30,
   SEESAW_ENCODER_DELTA = 0x40,
+};
+
+/** Audio spectrum module function address registers
+ */
+enum {
+  SEESAW_SPECTRUM_RESULTS_LOWER = 0x00, // Audio spectrum bins 0-31
+  SEESAW_SPECTRUM_RESULTS_UPPER = 0x01, // Audio spectrum bins 32-63
+  // If some future device supports a larger spectrum, can add additional
+  // "bins" working upward from here. Currently there is one configurable
+  // setting, via SEESAW_SPECTRUM_RATE (STATUS is basically a no-op).
+  // If more configurables are added in the future, work downward from
+  // here to avoid collision between spectrum bins & configurables.
+  SEESAW_SPECTRUM_RATE = 0xFE,
+  SEESAW_SPECTRUM_STATUS = 0xFF,
 };
 
 #define ADC_INPUT_0_PIN 2 ///< default ADC input pin

--- a/examples/audio_spectrum/Audio_Spectrum/Audio_Spectrum.ino
+++ b/examples/audio_spectrum/Audio_Spectrum/Audio_Spectrum.ino
@@ -2,7 +2,7 @@
   Audio Spectrum.
 
   This example shows how to set the audio sampling rate and read
-  audio spectrum data.
+  audio spectrum data from a compatible Seesaw device.
 */
 
 #include <seesaw_spectrum.h>
@@ -22,7 +22,15 @@ void setup() {
   }
   Serial.println("B");
 
-  ss.setRate(12); // Configure audio sampling rate
+  // Configure audio sampling rate, which determines the peak
+  // frequency of the spectrum output. There are 32 possible values
+  // (0-31), where lower numbers = higher frequency.
+  // The corresponding frequency for each setting will depend on the
+  // F_CPU frequency on the Seesaw device, which has not yet been
+  // determined. 10 or 20 MHz would be ideal, but others may happen,
+  // so specific numbers are not documented here yet.
+  // If 10 or 20 MHz, value of 12 here maps to 6250 Hz:
+  ss.setRate(12);
 }
 
 // The loop routine runs over and over again forever:

--- a/examples/audio_spectrum/Audio_Spectrum/Audio_Spectrum.ino
+++ b/examples/audio_spectrum/Audio_Spectrum/Audio_Spectrum.ino
@@ -28,5 +28,10 @@ void setup() {
 // The loop routine runs over and over again forever:
 void loop() {
   ss.getData(); // Pull audio spectrum data from device
-  Serial.println(ss.getLevel(10)); // What's in bin #10?
+  // Print contents of each of the 64 spectrum bins...
+  for (uint8_t i=0; i<64; i++) {
+    Serial.print(ss.getLevel(i));
+    Serial.write(' ');
+  }
+  Serial.println();
 }

--- a/examples/audio_spectrum/Audio_Spectrum/Audio_Spectrum.ino
+++ b/examples/audio_spectrum/Audio_Spectrum/Audio_Spectrum.ino
@@ -16,7 +16,7 @@ void setup() {
   while (!Serial) delay(10);   // wait until serial port is opened
   Serial.println("A");
   
-  if(!ss.begin()){
+  if (!ss.begin()) {
     Serial.println("seesaw not found!");
     while(1) delay(10);
   }
@@ -28,5 +28,5 @@ void setup() {
 // The loop routine runs over and over again forever:
 void loop() {
   ss.getData(); // Pull audio spectrum data from device
-  Serial.println(ss.getLevel(10));
+  Serial.println(ss.getLevel(10)); // What's in bin #10?
 }

--- a/examples/audio_spectrum/Audio_Spectrum/Audio_Spectrum.ino
+++ b/examples/audio_spectrum/Audio_Spectrum/Audio_Spectrum.ino
@@ -1,0 +1,32 @@
+/*
+  Audio Spectrum.
+
+  This example shows how to set the audio sampling rate and read
+  audio spectrum data.
+*/
+
+#include <seesaw_spectrum.h>
+
+seesaw_Audio_Spectrum ss;
+
+// The setup routine runs once when you press reset:
+void setup() {
+  Serial.begin(115200);
+  
+  while (!Serial) delay(10);   // wait until serial port is opened
+  Serial.println("A");
+  
+  if(!ss.begin()){
+    Serial.println("seesaw not found!");
+    while(1) delay(10);
+  }
+  Serial.println("B");
+
+  ss.setRate(12); // Configure audio sampling rate
+}
+
+// The loop routine runs over and over again forever:
+void loop() {
+  ss.getData(); // Pull audio spectrum data from device
+  Serial.println(ss.getLevel(10));
+}

--- a/seesaw_spectrum.cpp
+++ b/seesaw_spectrum.cpp
@@ -1,0 +1,32 @@
+#include "seesaw_spectrum.h"
+
+/**************************************************************************/
+/*!
+  @brief  Pull latest audio spectrum data from device.
+*/
+/**************************************************************************/
+void seesaw_Audio_Spectrum::getData(void) {
+  read(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RESULTS_LOWER, bins, 32, 0);
+  read(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RESULTS_UPPER, &bins[32], 32, 0);
+}
+
+/**************************************************************************/
+/*!
+  @brief  Set the audio sampling rate.
+  @param  value  Sampling rate index, 0-31. Values outside this range
+                 will be clipped.
+*/
+/**************************************************************************/
+void seesaw_Audio_Spectrum::setRate(uint8_t index) {
+  write8(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RATE, index);
+}
+
+/**************************************************************************/
+/*!
+  @brief   Query the current audio sampling rate.
+  @return  Sampling rate index, 0-31.
+*/
+/**************************************************************************/
+uint8_t seesaw_Audio_Spectrum::getRate(void) const {
+  return read8(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RATE);
+}

--- a/seesaw_spectrum.cpp
+++ b/seesaw_spectrum.cpp
@@ -6,9 +6,8 @@
 */
 /**************************************************************************/
 void seesaw_Audio_Spectrum::getData(void) {
-  this->read(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RESULTS_LOWER, bins, 32, 0);
-  this->read(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RESULTS_UPPER, &bins[32],
-             32, 0);
+  read(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RESULTS_LOWER, bins, 32, 0);
+  read(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RESULTS_UPPER, &bins[32], 32, 0);
 }
 
 /**************************************************************************/
@@ -19,7 +18,7 @@ void seesaw_Audio_Spectrum::getData(void) {
 */
 /**************************************************************************/
 void seesaw_Audio_Spectrum::setRate(uint8_t index) {
-  this->write8(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RATE, index);
+  write8(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RATE, index);
 }
 
 /**************************************************************************/

--- a/seesaw_spectrum.cpp
+++ b/seesaw_spectrum.cpp
@@ -6,8 +6,9 @@
 */
 /**************************************************************************/
 void seesaw_Audio_Spectrum::getData(void) {
-  read(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RESULTS_LOWER, bins, 32, 0);
-  read(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RESULTS_UPPER, &bins[32], 32, 0);
+  this->read(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RESULTS_LOWER, bins, 32, 0);
+  this->read(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RESULTS_UPPER, &bins[32],
+             32, 0);
 }
 
 /**************************************************************************/
@@ -18,7 +19,7 @@ void seesaw_Audio_Spectrum::getData(void) {
 */
 /**************************************************************************/
 void seesaw_Audio_Spectrum::setRate(uint8_t index) {
-  write8(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RATE, index);
+  this->write8(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RATE, index);
 }
 
 /**************************************************************************/
@@ -28,5 +29,5 @@ void seesaw_Audio_Spectrum::setRate(uint8_t index) {
 */
 /**************************************************************************/
 uint8_t seesaw_Audio_Spectrum::getRate(void) const {
-  return read8(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RATE);
+  return this->read8(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RATE);
 }

--- a/seesaw_spectrum.cpp
+++ b/seesaw_spectrum.cpp
@@ -28,6 +28,6 @@ void seesaw_Audio_Spectrum::setRate(uint8_t index) {
   @return  Sampling rate index, 0-31.
 */
 /**************************************************************************/
-uint8_t seesaw_Audio_Spectrum::getRate(void) const {
-  return this->read8(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RATE);
+uint8_t seesaw_Audio_Spectrum::getRate(void) {
+  return read8(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RATE);
 }

--- a/seesaw_spectrum.cpp
+++ b/seesaw_spectrum.cpp
@@ -17,8 +17,8 @@ void seesaw_Audio_Spectrum::getData(void) {
                  will be clipped.
 */
 /**************************************************************************/
-void seesaw_Audio_Spectrum::setRate(uint8_t index) {
-  write8(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RATE, index);
+void seesaw_Audio_Spectrum::setRate(uint8_t value) {
+  write8(SEESAW_SPECTRUM_BASE, SEESAW_SPECTRUM_RATE, value);
 }
 
 /**************************************************************************/

--- a/seesaw_spectrum.h
+++ b/seesaw_spectrum.h
@@ -14,13 +14,22 @@ public:
   /**************************************************************************/
   /*!
     @brief  seesaw_Audio_Spectrum class constructor.
-    @param  ss  Corresponding seesaw object this is working through.
+    @param  Wi  TwoWire interface this works through.
   */
   /**************************************************************************/
   seesaw_Audio_Spectrum(TwoWire *Wi = NULL) : Adafruit_seesaw(Wi) {}
 
   ~seesaw_Audio_Spectrum() {}
 
+  /**************************************************************************/
+  /*!
+    @brief  Begin communication with Seesaw audio spectrum device.
+    @param  addr  Optional i2c address where the device can be found.
+                  Defaults to SEESAW_ADDRESS.
+    @param  flow  Optional flow control pin.
+    @return true on success, false on error.
+  */
+  /**************************************************************************/
   bool begin(uint8_t addr = SEESAW_ADDRESS, int8_t flow = -1) {
     if (Adafruit_seesaw::begin(addr, flow)) {
       memset(bins, 0, sizeof bins);

--- a/seesaw_spectrum.h
+++ b/seesaw_spectrum.h
@@ -1,6 +1,7 @@
 #ifndef _SEESAW_SPECTRUM_H
 #define _SEESAW_SPECTRUM_H
 
+#include <Arduino.h>
 #include "Adafruit_seesaw.h"
 
 /**************************************************************************/

--- a/seesaw_spectrum.h
+++ b/seesaw_spectrum.h
@@ -1,0 +1,58 @@
+#ifndef _SEESAW_SPECTRUM_H
+#define _SEESAW_SPECTRUM_H
+
+#include "Adafruit_seesaw.h"
+
+/**************************************************************************/
+/*!
+    @brief  Class that stores state and functions for seesaw audio spectrum
+             interface
+*/
+/**************************************************************************/
+class seesaw_Audio_Spectrum : public Adafruit_seesaw {
+public:
+  /**************************************************************************/
+  /*!
+    @brief  seesaw_Audio_Spectrum class constructor.
+    @param  ss  Corresponding seesaw object this is working through.
+  */
+  /**************************************************************************/
+  seesaw_Audio_Spectrum(TwoWire *Wi=&Wire) : Adafruit_seesaw(Wi) {}
+
+  ~seesaw_Audio_Spectrum() {}
+
+  bool begin(uint8_t addr = SEESAW_ADDRESS, int8_t flow = -1) {
+    if (Adafruit_seesaw::begin(addr, flow)) {
+      memset(bins, 0, sizeof bins);
+      return true;
+    }
+    return false;
+  }
+
+  void getData(void); // Pull latest audio spectrum data from device
+  void setRate(uint8_t index); // Set audio sampling rage 0-31
+  uint8_t getRate(void) const; // Query audio sampling rate 0-31
+
+  /**************************************************************************/
+  /*!
+    @brief   Get value of individual spectrum bin, as determined during
+             most recent get_data() call.
+    @param   index  Spectrum bin index (0-63) to query.
+    @return  Level: 0 (silent) to 255 (loudest) for bin.
+  */
+  /**************************************************************************/
+  uint8_t getLevel(uint8_t index) const { return bins[min(index, 63)]; }
+
+  /**************************************************************************/
+  /*!
+    @brief   Get pointer to spectrum bin buffer directly. Use with caution!
+    @return  uint8_t base pointer to 64 spectrum bins.
+  */
+  /**************************************************************************/
+  uint8_t *getBuffer(void) const { return bins; }
+
+private:
+  uint8_t bins[64]; // Audio spectrum "bins"
+};
+
+#endif // end _SEESAW_SPECTRUM_H

--- a/seesaw_spectrum.h
+++ b/seesaw_spectrum.h
@@ -49,7 +49,7 @@ public:
     @return  uint8_t base pointer to 64 spectrum bins.
   */
   /**************************************************************************/
-  uint8_t *getBuffer(void) const { return bins; }
+  uint8_t *getBuffer(void) const { return (uint8_t *)bins; }
 
 private:
   uint8_t bins[64]; // Audio spectrum "bins"

--- a/seesaw_spectrum.h
+++ b/seesaw_spectrum.h
@@ -17,7 +17,7 @@ public:
     @param  ss  Corresponding seesaw object this is working through.
   */
   /**************************************************************************/
-  seesaw_Audio_Spectrum(TwoWire *Wi=&Wire) : Adafruit_seesaw(Wi) {}
+  seesaw_Audio_Spectrum(TwoWire *Wi=NULL) : Adafruit_seesaw(Wi) {}
 
   ~seesaw_Audio_Spectrum() {}
 

--- a/seesaw_spectrum.h
+++ b/seesaw_spectrum.h
@@ -31,7 +31,7 @@ public:
 
   void getData(void); // Pull latest audio spectrum data from device
   void setRate(uint8_t index); // Set audio sampling rage 0-31
-  uint8_t getRate(void) const; // Query audio sampling rate 0-31
+  uint8_t getRate(void); // Query audio sampling rate 0-31
 
   /**************************************************************************/
   /*!

--- a/seesaw_spectrum.h
+++ b/seesaw_spectrum.h
@@ -1,7 +1,6 @@
 #ifndef _SEESAW_SPECTRUM_H
 #define _SEESAW_SPECTRUM_H
 
-#include <Arduino.h>
 #include "Adafruit_seesaw.h"
 
 /**************************************************************************/
@@ -38,11 +37,11 @@ public:
   /*!
     @brief   Get value of individual spectrum bin, as determined during
              most recent get_data() call.
-    @param   index  Spectrum bin index (0-63) to query.
+    @param   idx  Spectrum bin index (0-63) to query.
     @return  Level: 0 (silent) to 255 (loudest) for bin.
   */
   /**************************************************************************/
-  uint8_t getLevel(uint8_t index) const { return bins[min(index, 63)]; }
+  uint8_t getLevel(uint8_t idx) const { return bins[idx < 64 ? idx : 63]; }
 
   /**************************************************************************/
   /*!

--- a/seesaw_spectrum.h
+++ b/seesaw_spectrum.h
@@ -17,7 +17,7 @@ public:
     @param  ss  Corresponding seesaw object this is working through.
   */
   /**************************************************************************/
-  seesaw_Audio_Spectrum(TwoWire *Wi=NULL) : Adafruit_seesaw(Wi) {}
+  seesaw_Audio_Spectrum(TwoWire *Wi = NULL) : Adafruit_seesaw(Wi) {}
 
   ~seesaw_Audio_Spectrum() {}
 
@@ -29,9 +29,9 @@ public:
     return false;
   }
 
-  void getData(void); // Pull latest audio spectrum data from device
+  void getData(void);          // Pull latest audio spectrum data from device
   void setRate(uint8_t index); // Set audio sampling rage 0-31
-  uint8_t getRate(void); // Query audio sampling rate 0-31
+  uint8_t getRate(void);       // Query audio sampling rate 0-31
 
   /**************************************************************************/
   /*!


### PR DESCRIPTION
This pairs up with a corresponding PR in Adafruit_seesawPeripheral. It demonstrates use of an FHT-enabled Seesaw device which performs live audio spectrum analysis.

The example reads from the Seesaw device and dumps all 64 spectrum “bins” to Serial out. A more interesting example might pair up with a display or LED matrix, but keeping this minimal to start. There was a Python script in another repo that paired up with a prototype of the FHT code…that same script still works with this example.