### PR TITLE
allow specifying the `i2c_bus` on neoKey and neoTrellis

### DIFF
--- a/Adafruit_NeoKey_1x4.cpp
+++ b/Adafruit_NeoKey_1x4.cpp
@@ -9,7 +9,7 @@
 /**************************************************************************/
 Adafruit_NeoKey_1x4::Adafruit_NeoKey_1x4(uint8_t addr, TwoWire *i2c_bus)
     : Adafruit_seesaw(i2c_bus), pixels(NEOKEY_1X4_KEYS, NEOKEY_1X4_NEOPIN,
-             NEO_GRB + NEO_KHZ800, i2c_bus) {
+                                       NEO_GRB + NEO_KHZ800, i2c_bus) {
   for (int i = 0; i < NEOKEY_1X4_KEYS; i++) {
     _callbacks[i] = NULL;
   }

--- a/Adafruit_NeoKey_1x4.cpp
+++ b/Adafruit_NeoKey_1x4.cpp
@@ -4,10 +4,12 @@
 /*!
     @brief  Class constructor
     @param  addr the I2C address this neotrellis object uses
+    @param  i2c_bus the I2C bus connected to this neokey, defaults to "Wire"
 */
 /**************************************************************************/
-Adafruit_NeoKey_1x4::Adafruit_NeoKey_1x4(uint8_t addr)
-    : pixels(NEOKEY_1X4_KEYS, NEOKEY_1X4_NEOPIN, NEO_GRB + NEO_KHZ800) {
+Adafruit_NeoKey_1x4::Adafruit_NeoKey_1x4(uint8_t addr, TwoWire *i2c_bus)
+    : Adafruit_seesaw(i2c_bus), pixels(NEOKEY_1X4_KEYS, NEOKEY_1X4_NEOPIN,
+             NEO_GRB + NEO_KHZ800, i2c_bus) {
   for (int i = 0; i < NEOKEY_1X4_KEYS; i++) {
     _callbacks[i] = NULL;
   }

--- a/Adafruit_NeoKey_1x4.h
+++ b/Adafruit_NeoKey_1x4.h
@@ -39,7 +39,7 @@ typedef void (*NeoKey1x4Callback)(keyEvent evt);
 /**************************************************************************/
 class Adafruit_NeoKey_1x4 : public Adafruit_seesaw {
 public:
-  Adafruit_NeoKey_1x4(uint8_t addr = NEOKEY_1X4_ADDR, TwoWire *i2c_bus = NULL);
+  Adafruit_NeoKey_1x4(uint8_t addr = NEOKEY_1X4_ADDR, TwoWire *i2c_bus = &Wire);
   ~Adafruit_NeoKey_1x4(){};
 
   bool begin(uint8_t addr = NEOKEY_1X4_ADDR, int8_t flow = -1);

--- a/Adafruit_NeoKey_1x4.h
+++ b/Adafruit_NeoKey_1x4.h
@@ -39,7 +39,7 @@ typedef void (*NeoKey1x4Callback)(keyEvent evt);
 /**************************************************************************/
 class Adafruit_NeoKey_1x4 : public Adafruit_seesaw {
 public:
-  Adafruit_NeoKey_1x4(uint8_t addr = NEOKEY_1X4_ADDR);
+  Adafruit_NeoKey_1x4(uint8_t addr = NEOKEY_1X4_ADDR, TwoWire *i2c_bus = NULL);
   ~Adafruit_NeoKey_1x4(){};
 
   bool begin(uint8_t addr = NEOKEY_1X4_ADDR, int8_t flow = -1);

--- a/Adafruit_NeoTrellis.cpp
+++ b/Adafruit_NeoTrellis.cpp
@@ -4,11 +4,12 @@
 /*!
     @brief  Class constructor
     @param  addr the I2C address this neotrellis object uses
+    @param  i2c_bus the I2C bus connected to this neotrellis, defaults to "Wire"
 */
 /**************************************************************************/
-Adafruit_NeoTrellis::Adafruit_NeoTrellis(uint8_t addr)
-    : pixels(NEO_TRELLIS_NUM_KEYS, NEO_TRELLIS_NEOPIX_PIN,
-             NEO_GRB + NEO_KHZ800) {
+Adafruit_NeoTrellis::Adafruit_NeoTrellis(uint8_t addr, TwoWire *i2c_bus)
+    : Adafruit_seesaw(i2c_bus), pixels(NEO_TRELLIS_NUM_KEYS, NEO_TRELLIS_NEOPIX_PIN,
+             NEO_GRB + NEO_KHZ800, i2c_bus) {
   for (int i = 0; i < NEO_TRELLIS_NUM_KEYS; i++) {
     _callbacks[i] = NULL;
   }

--- a/Adafruit_NeoTrellis.cpp
+++ b/Adafruit_NeoTrellis.cpp
@@ -8,8 +8,9 @@
 */
 /**************************************************************************/
 Adafruit_NeoTrellis::Adafruit_NeoTrellis(uint8_t addr, TwoWire *i2c_bus)
-    : Adafruit_seesaw(i2c_bus), pixels(NEO_TRELLIS_NUM_KEYS, NEO_TRELLIS_NEOPIX_PIN,
-             NEO_GRB + NEO_KHZ800, i2c_bus) {
+    : Adafruit_seesaw(i2c_bus),
+      pixels(NEO_TRELLIS_NUM_KEYS, NEO_TRELLIS_NEOPIX_PIN, NEO_GRB + NEO_KHZ800,
+             i2c_bus) {
   for (int i = 0; i < NEO_TRELLIS_NUM_KEYS; i++) {
     _callbacks[i] = NULL;
   }

--- a/Adafruit_NeoTrellis.h
+++ b/Adafruit_NeoTrellis.h
@@ -33,7 +33,8 @@ typedef void (*TrellisCallback)(keyEvent evt);
 /**************************************************************************/
 class Adafruit_NeoTrellis : public Adafruit_seesaw {
 public:
-  Adafruit_NeoTrellis(uint8_t addr = NEO_TRELLIS_ADDR, TwoWire *i2c_bus = NULL);
+  Adafruit_NeoTrellis(uint8_t addr = NEO_TRELLIS_ADDR,
+                      TwoWire *i2c_bus = &Wire);
   ~Adafruit_NeoTrellis(){};
 
   bool begin(uint8_t addr = NEO_TRELLIS_ADDR, int8_t flow = -1);

--- a/Adafruit_NeoTrellis.h
+++ b/Adafruit_NeoTrellis.h
@@ -33,7 +33,7 @@ typedef void (*TrellisCallback)(keyEvent evt);
 /**************************************************************************/
 class Adafruit_NeoTrellis : public Adafruit_seesaw {
 public:
-  Adafruit_NeoTrellis(uint8_t addr = NEO_TRELLIS_ADDR);
+  Adafruit_NeoTrellis(uint8_t addr = NEO_TRELLIS_ADDR, TwoWire *i2c_bus = NULL);
   ~Adafruit_NeoTrellis(){};
 
   bool begin(uint8_t addr = NEO_TRELLIS_ADDR, int8_t flow = -1);


### PR DESCRIPTION
This change is to allow specifying the `i2c_bus` on neoKey and neoTrellis initialization.

This was done to allow the use of these libraries with boards like the Adafruit Feather RP2040, where the stemma connector is on `Wire1` instead of `Wire0`.

Specifically for use with the Adafruit Feather RP2040, the following is required to use these libraries:
```
  // setup i2c for Adafruit Feather RP2040
  Wire1.setSDA(2);
  Wire1.setSCL(3);

  //setup neokey on Wire1
  neokey = Adafruit_NeoKey_1x4(NEOKEY_1X4_ADDR, &Wire1);
  neokey.begin()

  // setup neotrellis on Wire1
  trellis = Adafruit_NeoTrellis(NEO_TRELLIS_ADDR, &Wire1);
  trellis.begin()
```

After the above changes are applied, the examples should work as normal on the Adafruit Feather RP2040 board.




