### PR TITLE
Macro NEO_TRELLIS_XY fix

### DIFF
--- a/Adafruit_NeoTrellis.h
+++ b/Adafruit_NeoTrellis.h
@@ -21,7 +21,7 @@
 #define NEO_TRELLIS_X(k) ((k) % 4)
 #define NEO_TRELLIS_Y(k) ((k) / 4)
 
-#define NEO_TRELLIS_XY(x, y) ((y)*NEO_TRELLIS_NUM_ROWS + (x))
+#define NEO_TRELLIS_XY(x, y) ((y)*NEO_TRELLIS_NUM_COLS + (x))
 
 typedef void (*TrellisCallback)(keyEvent evt);
 


### PR DESCRIPTION
Macro NEO_TRELLIS_XY(x,y)
was defined as
((y)*NEO_TRELLIS_NUM_ROWS + (x))
but it should be
((y)*NEO_TRELLIS_NUM_COLS + (x))

As NEO_TRELLIS_NUM_ROWS  and NEO_TRELLIS_NUM_COLS  are both identical (4), it doesn't make a difference, but in fact it only works by accident

So, this code will not result in any change, as long as NEO_TRELLIS_NUM_ROWS and NEO_TRELLIS_NUM_COLS remain 4