### PR TITLE
Added polling flag to MultiTrellis::read

### DIFF
--- a/Adafruit_NeoTrellis.cpp
+++ b/Adafruit_NeoTrellis.cpp
@@ -49,7 +49,7 @@ bool Adafruit_NeoTrellis::begin(uint8_t addr, int8_t flow) {
 */
 /**************************************************************************/
 void Adafruit_NeoTrellis::registerCallback(uint8_t key,
-                                           TrellisCallback (*cb)(keyEvent)) {
+                                           TrellisCallback cb) {
   _callbacks[key] = cb;
 }
 
@@ -153,7 +153,7 @@ bool Adafruit_MultiTrellis::begin() {
 */
 /**************************************************************************/
 void Adafruit_MultiTrellis::registerCallback(uint8_t x, uint8_t y,
-                                             TrellisCallback (*cb)(keyEvent)) {
+                                             TrellisCallback cb) {
   Adafruit_NeoTrellis *t =
       (_trelli + y / NEO_TRELLIS_NUM_ROWS * _cols) + x / NEO_TRELLIS_NUM_COLS;
   int xkey = NEO_TRELLIS_X(x);
@@ -173,7 +173,7 @@ void Adafruit_MultiTrellis::registerCallback(uint8_t x, uint8_t y,
 */
 /**************************************************************************/
 void Adafruit_MultiTrellis::registerCallback(uint16_t num,
-                                             TrellisCallback (*cb)(keyEvent)) {
+                                             TrellisCallback cb) {
   uint8_t x = num % (NEO_TRELLIS_NUM_COLS * _cols);
   uint8_t y = num / (NEO_TRELLIS_NUM_COLS * _cols);
 

--- a/Adafruit_NeoTrellis.cpp
+++ b/Adafruit_NeoTrellis.cpp
@@ -317,7 +317,7 @@ void Adafruit_MultiTrellis::show() {
    callbacks.
 */
 /**************************************************************************/
-void Adafruit_MultiTrellis::read() {
+void Adafruit_MultiTrellis::read(bool polling) {
   Adafruit_NeoTrellis *t;
   for (int n = 0; n < _rows; n++) {
     for (int m = 0; m < _cols; m++) {
@@ -326,7 +326,8 @@ void Adafruit_MultiTrellis::read() {
       uint8_t count = t->getKeypadCount();
       delayMicroseconds(500);
       if (count > 0) {
-        count = count + 2;
+        if (polling)
+          count = count + 2;
         keyEventRaw e[count];
         t->readKeypad(e, count);
         for (int i = 0; i < count; i++) {

--- a/Adafruit_NeoTrellis.cpp
+++ b/Adafruit_NeoTrellis.cpp
@@ -315,6 +315,8 @@ void Adafruit_MultiTrellis::show() {
 /*!
     @brief  read all events currently stored in the seesaw fifo and call any
    callbacks.
+    @param  polling pass true if the interrupt pin is not being used, false if
+   it is. Defaults to true.
 */
 /**************************************************************************/
 void Adafruit_MultiTrellis::read(bool polling) {

--- a/Adafruit_NeoTrellis.h
+++ b/Adafruit_NeoTrellis.h
@@ -39,7 +39,7 @@ public:
 
   bool begin(uint8_t addr = NEO_TRELLIS_ADDR, int8_t flow = -1);
 
-  void registerCallback(uint8_t key, TrellisCallback (*cb)(keyEvent));
+  void registerCallback(uint8_t key, TrellisCallback cb);
   void unregisterCallback(uint8_t key);
 
   void activateKey(uint8_t key, uint8_t edge, bool enable = true);
@@ -53,8 +53,7 @@ public:
 
 protected:
   uint8_t _addr; ///< the I2C address of this board
-  TrellisCallback (*_callbacks[NEO_TRELLIS_NUM_KEYS])(
-      keyEvent); ///< the array of callback functions
+  TrellisCallback _callbacks[NEO_TRELLIS_NUM_KEYS]; ///< the array of callback functions
 };
 
 /**************************************************************************/
@@ -71,8 +70,8 @@ public:
 
   bool begin();
 
-  void registerCallback(uint16_t num, TrellisCallback (*cb)(keyEvent));
-  void registerCallback(uint8_t x, uint8_t y, TrellisCallback (*cb)(keyEvent));
+  void registerCallback(uint16_t num, TrellisCallback cb);
+  void registerCallback(uint8_t x, uint8_t y, TrellisCallback cb);
   void unregisterCallback(uint16_t num);
   void unregisterCallback(uint8_t x, uint8_t y);
 

--- a/Adafruit_NeoTrellis.h
+++ b/Adafruit_NeoTrellis.h
@@ -83,7 +83,7 @@ public:
   void setPixelColor(uint16_t num, uint32_t color);
   void show();
 
-  void read();
+  void read(bool polling = true);
 
 protected:
   uint8_t _rows; ///< the number of trellis boards in the Y direction

--- a/examples/NeoTrellis/multitrellis/basic/basic.ino
+++ b/examples/NeoTrellis/multitrellis/basic/basic.ino
@@ -55,7 +55,7 @@ uint32_t Wheel(byte WheelPos) {
 }
 
 //define a callback for key presses
-TrellisCallback blink(keyEvent evt){
+void blink(keyEvent evt){
   
   if(evt.bit.EDGE == SEESAW_KEYPAD_EDGE_RISING)
     trellis.setPixelColor(evt.bit.NUM, Wheel(map(evt.bit.NUM, 0, X_DIM*Y_DIM, 0, 255))); //on rising
@@ -63,7 +63,6 @@ TrellisCallback blink(keyEvent evt){
     trellis.setPixelColor(evt.bit.NUM, 0); //off falling
     
   trellis.show();
-  return 0;
 }
 
 void setup() {


### PR DESCRIPTION
The` read() `method in `MultiTrellis `does not currently support the `polling `flag. This results in unnecessary bus activity which injects noise in to the PSU for audio applications.

This PR adds the flag, default to true if not supplied so as not to change the API for existing apps.

This PR also duplicates the logic` if (polling) count = count + 2;` which exists in the NeoTrellis::read(0 method. However I have no idea what this actually does (there is no comment explaining it). But it works for me :-)