### PR TITLE
Fix setting I2C address on ATtinys

### DIFF
--- a/Adafruit_seesaw.cpp
+++ b/Adafruit_seesaw.cpp
@@ -628,6 +628,33 @@ char Adafruit_seesaw::readSercomData(uint8_t sercom) {
 
 /*!
  *****************************************************************************************
+ *  @brief      Return the EEPROM address used to store I2C address
+ *
+ *  @return     the EEPROM address location
+ ****************************************************************************************/
+uint8_t Adafruit_seesaw::getI2CaddrEEPROMloc() {
+  // All SAMDs use fixed location -> 0x3F
+  // ATtinys place at end of EEPROM, so can vary:
+  //   8xx have 128B of EEPROM -> 0x7F
+  //   16xx have 256B of EERPOM -> 0xFF
+  switch (_hardwaretype) {
+  case SEESAW_HW_ID_CODE_SAMD09:
+    return 0x3F;
+  case SEESAW_HW_ID_CODE_TINY817:
+  case SEESAW_HW_ID_CODE_TINY807:
+  case SEESAW_HW_ID_CODE_TINY816:
+  case SEESAW_HW_ID_CODE_TINY806:
+    return 0x7F;
+  case SEESAW_HW_ID_CODE_TINY1616:
+  case SEESAW_HW_ID_CODE_TINY1617:
+    return 0xFF;
+  default:
+    return 0x00;
+  }
+}
+
+/*!
+ *****************************************************************************************
  *  @brief      Set the seesaw I2C address. This will automatically call
  *Adafruit_seesaw.begin() with the new address.
  *
@@ -635,7 +662,7 @@ char Adafruit_seesaw::readSercomData(uint8_t sercom) {
  *I2C address.
  ****************************************************************************************/
 void Adafruit_seesaw::setI2CAddr(uint8_t addr) {
-  this->EEPROMWrite8(SEESAW_EEPROM_I2C_ADDR, addr);
+  this->EEPROMWrite8(getI2CaddrEEPROMloc(), addr);
   delay(250);
   this->begin(addr); // restart w/ the new addr
 }
@@ -648,7 +675,7 @@ void Adafruit_seesaw::setI2CAddr(uint8_t addr) {
  *already know because you just read data from it.
  ****************************************************************************************/
 uint8_t Adafruit_seesaw::getI2CAddr() {
-  return this->read8(SEESAW_EEPROM_BASE, SEESAW_EEPROM_I2C_ADDR);
+  return this->EEPROMRead8(getI2CaddrEEPROMloc());
 }
 
 /*!

--- a/Adafruit_seesaw.h
+++ b/Adafruit_seesaw.h
@@ -199,10 +199,6 @@ enum {
 #define SEESAW_HW_ID_CODE_TINY1617 0x89 ///< seesaw HW ID code for ATtiny1617
 // clang-format on
 
-#define SEESAW_EEPROM_I2C_ADDR                                                 \
-  0x3F ///< EEPROM address of i2c address to start up with (for devices that
-       ///< support this feature)
-
 /** raw key event stucture for keypad module */
 union keyEventRaw {
   struct {
@@ -310,6 +306,7 @@ protected:
   int8_t _flow; /*!< The flow control pin to use */
 
   uint8_t _hardwaretype = 0; /*!< what hardware type is attached! */
+  uint8_t getI2CaddrEEPROMloc();
 
   bool write8(byte regHigh, byte regLow, byte value);
   uint8_t read8(byte regHigh, byte regLow, uint16_t delay = 250);


### PR DESCRIPTION
For #93.

Tested on a PID 5743 (gamepad) using following sketch to change I2C address:
```cpp
#include "Adafruit_seesaw.h"

#define OLD_ADDR 0x50
#define NEW_ADDR 0x55

Adafruit_seesaw ss;

void setup() {
  Serial.begin(9600);
  while (!Serial);

  Serial.println("EEPROM I2C address change test.");

  if (!ss.begin(OLD_ADDR)) {
    Serial.println("seesaw not found.");
    while(1);
  }

  Serial.println("seesaw started.");

  Serial.println("Changing I2C address...");
  ss.setI2CAddr(NEW_ADDR);
  Serial.println("Done.");
}

void loop() {
}
```

**NOTE** - I2C breaks after the address change (after call to `setI2CAddr()`)and the attempt to restart it doesn't seem to work. But power cycling works and the device comes up at the newly set I2C address.