### PR TITLE
Update setPWMFreq for ATTiny variants

### DIFF
--- a/Adafruit_seesaw.cpp
+++ b/Adafruit_seesaw.cpp
@@ -563,22 +563,35 @@ void Adafruit_seesaw::analogWrite(uint8_t pin, uint16_t value, uint8_t width) {
  ******************************************************************************/
 void Adafruit_seesaw::setPWMFreq(uint8_t pin, uint16_t freq) {
   int8_t p = -1;
-  switch (pin) {
-  case PWM_0_PIN:
-    p = 0;
-    break;
-  case PWM_1_PIN:
-    p = 1;
-    break;
-  case PWM_2_PIN:
-    p = 2;
-    break;
-  case PWM_3_PIN:
-    p = 3;
-    break;
-  default:
-    break;
+
+  if (_hardwaretype == SEESAW_HW_ID_CODE_SAMD09) {
+    switch (pin) {
+    case PWM_0_PIN:
+      p = 0;
+      break;
+    case PWM_1_PIN:
+      p = 1;
+      break;
+    case PWM_2_PIN:
+      p = 2;
+      break;
+    case PWM_3_PIN:
+      p = 3;
+      break;
+    default:
+      break;
+    }
+  } else if ((_hardwaretype == SEESAW_HW_ID_CODE_TINY817) ||
+             (_hardwaretype == SEESAW_HW_ID_CODE_TINY807) ||
+             (_hardwaretype == SEESAW_HW_ID_CODE_TINY816) ||
+             (_hardwaretype == SEESAW_HW_ID_CODE_TINY806) ||
+             (_hardwaretype == SEESAW_HW_ID_CODE_TINY1616) ||
+             (_hardwaretype == SEESAW_HW_ID_CODE_TINY1617)) {
+    p = pin;
+  } else {
+    return;
   }
+
   if (p > -1) {
     uint8_t cmd[] = {(uint8_t)p, (uint8_t)(freq >> 8), (uint8_t)freq};
     this->write(SEESAW_TIMER_BASE, SEESAW_TIMER_FREQ, cmd, 3);


### PR DESCRIPTION
For #98.

Fixes logic in `setPWMFreq()` to support the ATTiny variants, similar to same logic found in `analogWrite()`.

Tested with following example sketch running on a QT PY M0 attached to an ATTiny1616 dev breakout (PID 5690) and scoping pin 1:
```cpp
#include <Adafruit_seesaw.h>

Adafruit_seesaw ss;

void setup() {
  Serial.begin(115200);
  while (!Serial);
  
  Serial.println("Seesaw PWM Test.");

  if (!ss.begin()) {
    Serial.println("Failed to init seesaw.");
    while(1);
  }
  Serial.println("Seesaw initd.");
}

void loop() {
  ss.setPWMFreq(1, 100);
  delay(2000);
  ss.setPWMFreq(1, 300);
  delay(2000);
}
```

**BEFORE**
no output
![before](https://github.com/adafruit/Adafruit_Seesaw/assets/8755041/09520191-e43e-494a-9b96-0e0b15e1272e)


**AFTER**
expected output
![after1](https://github.com/adafruit/Adafruit_Seesaw/assets/8755041/cca1119f-97d8-4753-a7a3-38768e18565d)
![after2](https://github.com/adafruit/Adafruit_Seesaw/assets/8755041/dd8ac1bd-090b-4094-b9cf-a04e963f9abf)


