### PR TITLE
Resolve -Woverloaded-virtual warnings

### DIFF
--- a/Adafruit_NeoKey_1x4.h
+++ b/Adafruit_NeoKey_1x4.h
@@ -27,7 +27,7 @@
 #define NEOKEY_1X4_X(k) ((k) % 4)
 #define NEOKEY_1X4_Y(k) ((k) / 4)
 
-#define NEOKEY_1X4_XY(x, y) ((y)*NEOKEY_1X4_ROWS + (x))
+#define NEOKEY_1X4_XY(x, y) ((y) * NEOKEY_1X4_ROWS + (x))
 
 typedef void (*NeoKey1x4Callback)(keyEvent evt);
 

--- a/Adafruit_NeoTrellis.h
+++ b/Adafruit_NeoTrellis.h
@@ -21,7 +21,7 @@
 #define NEO_TRELLIS_X(k) ((k) % 4)
 #define NEO_TRELLIS_Y(k) ((k) / 4)
 
-#define NEO_TRELLIS_XY(x, y) ((y)*NEO_TRELLIS_NUM_COLS + (x))
+#define NEO_TRELLIS_XY(x, y) ((y) * NEO_TRELLIS_NUM_COLS + (x))
 
 typedef void (*TrellisCallback)(keyEvent evt);
 

--- a/Adafruit_seesaw.cpp
+++ b/Adafruit_seesaw.cpp
@@ -29,7 +29,7 @@
 #include "Adafruit_seesaw.h"
 #include <Arduino.h>
 
-//#define SEESAW_I2C_DEBUG
+// #define SEESAW_I2C_DEBUG
 
 /*!
  *****************************************************************************************

--- a/Adafruit_seesaw.h
+++ b/Adafruit_seesaw.h
@@ -296,7 +296,8 @@ public:
   bool disableEncoderInterrupt(uint8_t encoder = 0);
   void setEncoderPosition(int32_t pos, uint8_t encoder = 0);
 
-  virtual size_t write(uint8_t);
+  using Print::write;
+  virtual size_t write(uint8_t) override;
   virtual size_t write(const char *str);
 
 protected:


### PR DESCRIPTION
When compiling with -Woverloaded-virtual, warnings are generated due to the overloading of Print::write.

```
warning: 'virtual size_t Print::write(const uint8_t*, size_t)' was hidden [-Woverloaded-virtual=]
lib/Adafruit_Seesaw/Adafruit_seesaw.h:316:8: note:   by 'Adafruit_seesaw::write'
  316 |   bool write(uint8_t regHigh, uint8_t regLow, uint8_t *buf, uint8_t num);
      |        ^~~~~
```

Pulling the definitions of Print::write into Adafruit_seesaw resolves this warning.