### PR TITLE
Added support for Arduino ESP32 core

### DIFF
--- a/Adafruit_Crickit.cpp
+++ b/Adafruit_Crickit.cpp
@@ -1,5 +1,21 @@
 #include "Adafruit_Crickit.h"
 
+// ESP32 core has macros that interfere with the compilation
+#ifdef ARDUINO_ARCH_ESP32
+#pragma push_macro("pinMode")
+#undef pinMode
+#pragma push_macro("analogWrite")
+#undef analogWrite
+#pragma push_macro("analogRead")
+#undef analogRead
+#pragma push_macro("digitalRead")
+#undef digitalRead
+#pragma push_macro("digitalWrite")
+#undef digitalWrite
+#pragma push_macro("touchRead")
+#undef touchRead
+#endif
+
 // the pwm pins
 #define CRICKIT_NUM_PWM 12
 static const uint8_t CRICKIT_pwms[CRICKIT_NUM_PWM] = {
@@ -63,3 +79,13 @@ void Adafruit_Crickit::setPWMFreq(uint8_t pin, uint16_t freq) {
     this->write(SEESAW_TIMER_BASE, SEESAW_TIMER_FREQ, cmd, 3);
   }
 }
+
+// ESP32 core macros reinstate
+#ifdef ARDUINO_ARCH_ESP32
+#pragma pop_macro("touchRead")
+#pragma pop_macro("digitalWrite")
+#pragma pop_macro("digitalRead")
+#pragma pop_macro("analogRead")
+#pragma pop_macro("analogWrite")
+#pragma pop_macro("pinMode")
+#endif

--- a/Adafruit_Crickit.cpp
+++ b/Adafruit_Crickit.cpp
@@ -1,6 +1,6 @@
 #include "Adafruit_Crickit.h"
 
-// ESP32 core has macros that interfere with the compilation
+// ESP32 core has macros that interfere with the compilation
 #ifdef ARDUINO_ARCH_ESP32
 #pragma push_macro("pinMode")
 #undef pinMode

--- a/Adafruit_Crickit.h
+++ b/Adafruit_Crickit.h
@@ -34,7 +34,7 @@
 #define CRICKIT_DUTY_CYCLE_OFF 0
 #define CRICKIT_DUTY_CYCLE_MAX 65535
 
-// ESP32 core has macros that interfere with the compilation
+// ESP32 core has macros that interfere with the compilation
 #ifdef ARDUINO_ARCH_ESP32
 #pragma push_macro("pinMode")
 #undef pinMode

--- a/Adafruit_Crickit.h
+++ b/Adafruit_Crickit.h
@@ -34,6 +34,22 @@
 #define CRICKIT_DUTY_CYCLE_OFF 0
 #define CRICKIT_DUTY_CYCLE_MAX 65535
 
+// ESP32 core has macros that interfere with the compilation
+#ifdef ARDUINO_ARCH_ESP32
+#pragma push_macro("pinMode")
+#undef pinMode
+#pragma push_macro("analogWrite")
+#undef analogWrite
+#pragma push_macro("analogRead")
+#undef analogRead
+#pragma push_macro("digitalRead")
+#undef digitalRead
+#pragma push_macro("digitalWrite")
+#undef digitalWrite
+#pragma push_macro("touchRead")
+#undef touchRead
+#endif
+
 /**************************************************************************/
 /*!
     @brief  Class that stores state and functions for interacting with Crickit
@@ -50,4 +66,14 @@ public:
   void setPWMFreq(uint8_t pin, uint16_t freq);
 };
 
+#endif
+
+// ESP32 core macros reinstate
+#ifdef ARDUINO_ARCH_ESP32
+#pragma pop_macro("touchRead")
+#pragma pop_macro("digitalWrite")
+#pragma pop_macro("digitalRead")
+#pragma pop_macro("analogRead")
+#pragma pop_macro("analogWrite")
+#pragma pop_macro("pinMode")
 #endif

--- a/Adafruit_Crickit.h
+++ b/Adafruit_Crickit.h
@@ -52,7 +52,7 @@
 
 /**************************************************************************/
 /*!
-    @brief  Class that stores state and functions for interacting with Crickit
+   @brief  Class that stores state and functions for interacting with Crickit
    variant of seesaw helper IC
 */
 /**************************************************************************/

--- a/Adafruit_NeoKey_1x4.h
+++ b/Adafruit_NeoKey_1x4.h
@@ -27,7 +27,7 @@
 #define NEOKEY_1X4_X(k) ((k) % 4)
 #define NEOKEY_1X4_Y(k) ((k) / 4)
 
-#define NEOKEY_1X4_XY(x, y) ((y)*NEOKEY_1X4_ROWS + (x))
+#define NEOKEY_1X4_XY(x, y) ((y) * NEOKEY_1X4_ROWS + (x))
 
 typedef void (*NeoKey1x4Callback)(keyEvent evt);
 

--- a/Adafruit_NeoTrellis.h
+++ b/Adafruit_NeoTrellis.h
@@ -21,7 +21,7 @@
 #define NEO_TRELLIS_X(k) ((k) % 4)
 #define NEO_TRELLIS_Y(k) ((k) / 4)
 
-#define NEO_TRELLIS_XY(x, y) ((y)*NEO_TRELLIS_NUM_COLS + (x))
+#define NEO_TRELLIS_XY(x, y) ((y) * NEO_TRELLIS_NUM_COLS + (x))
 
 typedef void (*TrellisCallback)(keyEvent evt);
 

--- a/Adafruit_seesaw.cpp
+++ b/Adafruit_seesaw.cpp
@@ -31,6 +31,22 @@
 
 // #define SEESAW_I2C_DEBUG
 
+// ESP32 core has macros that interfere with the compilation
+#ifdef ARDUINO_ARCH_ESP32
+#pragma push_macro("pinMode")
+#undef pinMode
+#pragma push_macro("analogWrite")
+#undef analogWrite
+#pragma push_macro("analogRead")
+#undef analogRead
+#pragma push_macro("digitalRead")
+#undef digitalRead
+#pragma push_macro("digitalWrite")
+#undef digitalWrite
+#pragma push_macro("touchRead")
+#undef touchRead
+#endif
+
 /*!
  *****************************************************************************************
  *  @brief      Create a seesaw object on a given I2C bus
@@ -1045,3 +1061,13 @@ size_t Adafruit_seesaw::write(const char *str) {
   this->write(SEESAW_SERCOM0_BASE, SEESAW_SERCOM_DATA, buf, len);
   return len;
 }
+
+// ESP32 core macros reinstate
+#ifdef ARDUINO_ARCH_ESP32
+#pragma pop_macro("touchRead")
+#pragma pop_macro("digitalWrite")
+#pragma pop_macro("digitalRead")
+#pragma pop_macro("analogRead")
+#pragma pop_macro("analogWrite")
+#pragma pop_macro("pinMode")
+#endif

--- a/Adafruit_seesaw.cpp
+++ b/Adafruit_seesaw.cpp
@@ -31,7 +31,7 @@
 
 // #define SEESAW_I2C_DEBUG
 
-// ESP32 core has macros that interfere with the compilation
+// ESP32 core has macros that interfere with the compilation
 #ifdef ARDUINO_ARCH_ESP32
 #pragma push_macro("pinMode")
 #undef pinMode

--- a/Adafruit_seesaw.cpp
+++ b/Adafruit_seesaw.cpp
@@ -29,7 +29,7 @@
 #include "Adafruit_seesaw.h"
 #include <Arduino.h>
 
-//#define SEESAW_I2C_DEBUG
+// #define SEESAW_I2C_DEBUG
 
 /*!
  *****************************************************************************************

--- a/Adafruit_seesaw.h
+++ b/Adafruit_seesaw.h
@@ -209,7 +209,6 @@ enum {
 #undef touchRead
 #endif
 
-
 /** raw key event stucture for keypad module */
 union keyEventRaw {
   struct {

--- a/Adafruit_seesaw.h
+++ b/Adafruit_seesaw.h
@@ -31,6 +31,22 @@
 #define SEESAW_ADDRESS (0x49) ///< Default Seesaw I2C address
 /*=========================================================================*/
 
+// ESP32 core has macros that interfere with the compilation
+#ifdef ARDUINO_ARCH_ESP32
+#pragma push_macro("pinMode")
+#undef pinMode
+#pragma push_macro("analogWrite")
+#undef analogWrite
+#pragma push_macro("analogRead")
+#undef analogRead
+#pragma push_macro("digitalRead")
+#undef digitalRead
+#pragma push_macro("digitalWrite")
+#undef digitalWrite
+#pragma push_macro("touchRead")
+#undef touchRead
+#endif
+
 /*=========================================================================
     REGISTERS
     -----------------------------------------------------------------------*/
@@ -199,16 +215,6 @@ enum {
 #define SEESAW_HW_ID_CODE_TINY1617 0x89 ///< seesaw HW ID code for ATtiny1617
 // clang-format on
 
-// ESP32 core macros remove
-#ifdef ARDUINO_ARCH_ESP32
-#undef pinMode
-#undef analogWrite
-#undef analogRead
-#undef digitalWrite
-#undef digitalRead
-#undef touchRead
-#endif
-
 /** raw key event stucture for keypad module */
 union keyEventRaw {
   struct {
@@ -342,4 +348,14 @@ protected:
   /*=========================================================================*/
 };
 
+#endif
+
+// ESP32 core macros reinstate
+#ifdef ARDUINO_ARCH_ESP32
+#pragma pop_macro("touchRead")
+#pragma pop_macro("digitalWrite")
+#pragma pop_macro("digitalRead")
+#pragma pop_macro("analogRead")
+#pragma pop_macro("analogWrite")
+#pragma pop_macro("pinMode")
 #endif

--- a/Adafruit_seesaw.h
+++ b/Adafruit_seesaw.h
@@ -199,6 +199,17 @@ enum {
 #define SEESAW_HW_ID_CODE_TINY1617 0x89 ///< seesaw HW ID code for ATtiny1617
 // clang-format on
 
+// ESP32 core macros remove
+#ifdef ARDUINO_ARCH_ESP32
+#undef pinMode
+#undef analogWrite
+#undef analogRead
+#undef digitalWrite
+#undef digitalRead
+#undef touchRead
+#endif
+
+
 /** raw key event stucture for keypad module */
 union keyEventRaw {
   struct {

--- a/Adafruit_seesaw.h
+++ b/Adafruit_seesaw.h
@@ -31,7 +31,7 @@
 #define SEESAW_ADDRESS (0x49) ///< Default Seesaw I2C address
 /*=========================================================================*/
 
-// ESP32 core has macros that interfere with the compilation
+// ESP32 core has macros that interfere with the compilation
 #ifdef ARDUINO_ARCH_ESP32
 #pragma push_macro("pinMode")
 #undef pinMode


### PR DESCRIPTION
Added support for Arduino ESP32 core by undefining the core macros that conflict with this library, when the library is compiled

I have only tested it on the Arduino Nano ESP32
